### PR TITLE
changes to addin info publishing

### DIFF
--- a/Project Monitor/src/HOK.MissionControl/HOK.MissionControl.Core/Properties/AssemblyInfo.cs
+++ b/Project Monitor/src/HOK.MissionControl/HOK.MissionControl.Core/Properties/AssemblyInfo.cs
@@ -10,8 +10,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("HOK Group")]
 [assembly: AssemblyProduct("HOK.MissionControl.Core")]
-[assembly: AssemblyCopyright("Copyright © HOK Group 2016")]
-[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCopyright("Copyright © HOK Group 2018")]
+[assembly: AssemblyTrademark("Jinsol Kim, Konrad K Sobon")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 //[assembly: AssemblyVersion("2017.0.*")]
-[assembly: AssemblyVersion("2018.0.0.17")]
+[assembly: AssemblyVersion("2018.0.0.18")]
 //[assembly: AssemblyFileVersion("2017.0.1.0")]

--- a/Project Monitor/src/HOK.MissionControl/HOK.MissionControl.FamilyPublish/FamilyPublishCommand.cs
+++ b/Project Monitor/src/HOK.MissionControl/HOK.MissionControl.FamilyPublish/FamilyPublishCommand.cs
@@ -36,7 +36,8 @@ namespace HOK.MissionControl.FamilyPublish
             {
                 // (Konrad) We are gathering information about the addin use. This allows us to
                 // better maintain the most used plug-ins or discontiue the unused ones.
-                AddinUtilities.PublishAddinLog(new AddinLog("MissionControl-PublishFamilyData", commandData.Application.Application.VersionNumber));
+                var unused1 = AddinUtilities.PublishAddinLog(
+                    new AddinLog("MissionControl-PublishFamilyData", commandData.Application.Application.VersionNumber), LogPosted);
 
                 var pathName = doc.PathName;
                 if (string.IsNullOrEmpty(pathName))
@@ -127,6 +128,16 @@ namespace HOK.MissionControl.FamilyPublish
             uiApp.Application.FailuresProcessing -= FailureProcessing;
             Log.AppendLog(LogMessageType.INFO, "Ended");
             return Result.Succeeded;
+        }
+
+        /// <summary>
+        /// Callback method for when Addin-info is published.
+        /// </summary>
+        /// <param name="data"></param>
+        private static void LogPosted(AddinData data)
+        {
+            Log.AppendLog(LogMessageType.INFO, "Addin info was published: "
+                + (string.IsNullOrEmpty(data.Id) ? "Unsuccessfully." : "Successfully."));
         }
 
         /// <summary>

--- a/Project Monitor/src/HOK.MissionControl/HOK.MissionControl.FamilyPublish/Properties/AssemblyInfo.cs
+++ b/Project Monitor/src/HOK.MissionControl/HOK.MissionControl.FamilyPublish/Properties/AssemblyInfo.cs
@@ -8,10 +8,10 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("HOK.MissionControl.FamilyPublish")]
 [assembly: AssemblyDescription("Publishes information about Families to Mission Control server.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("HOK")]
+[assembly: AssemblyCompany("HOK Group")]
 [assembly: AssemblyProduct("HOK.MissionControl.FamilyPublish")]
-[assembly: AssemblyCopyright("Copyright © HOK Group 2017")]
-[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCopyright("Copyright © HOK Group 2018")]
+[assembly: AssemblyTrademark("Konrad K Sobon")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
@@ -34,5 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 //[assembly: AssemblyVersion("2018.0.0.2")]
 //[assembly: AssemblyVersion("2018.0.*")]
-[assembly: AssemblyVersion("2018.0.0.17")]
+[assembly: AssemblyVersion("2018.0.0.18")]
 //[assembly: AssemblyFileVersion("2018.0.0.2")]

--- a/Project Monitor/src/HOK.MissionControl/HOK.MissionControl.LinksManager/LinksManagerCommand.cs
+++ b/Project Monitor/src/HOK.MissionControl/HOK.MissionControl.LinksManager/LinksManagerCommand.cs
@@ -31,8 +31,8 @@ namespace HOK.MissionControl.LinksManager
             {
                 // (Konrad) We are gathering information about the addin use. This allows us to
                 // better maintain the most used plug-ins or discontiue the unused ones.
-                AddinUtilities.PublishAddinLog(new AddinLog("MissionControl-LinksManager",
-                    commandData.Application.Application.VersionNumber));
+                var unused1 = AddinUtilities.PublishAddinLog(
+                    new AddinLog("MissionControl-LinksManager", commandData.Application.Application.VersionNumber), LogPosted);
 
                 var viewModel = new LinksManagerViewModel(doc);
                 var view = new LinksManagerView
@@ -54,6 +54,16 @@ namespace HOK.MissionControl.LinksManager
 
             Log.AppendLog(LogMessageType.INFO, "Ended");
             return Result.Succeeded;
+        }
+
+        /// <summary>
+        /// Callback method for when Addin-info is published.
+        /// </summary>
+        /// <param name="data"></param>
+        private static void LogPosted(AddinData data)
+        {
+            Log.AppendLog(LogMessageType.INFO, "Addin info was published: " 
+                + (string.IsNullOrEmpty(data.Id) ? "Unsuccessfully." : "Successfully."));
         }
     }
 }

--- a/Project Monitor/src/HOK.MissionControl/HOK.MissionControl.LinksManager/Properties/AssemblyInfo.cs
+++ b/Project Monitor/src/HOK.MissionControl/HOK.MissionControl.LinksManager/Properties/AssemblyInfo.cs
@@ -6,12 +6,12 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("HOK.MissionControl.LinksManager")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("This application allows you to manage the links, imports, and object styles in the model.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("HOK Group")]
 [assembly: AssemblyProduct("HOK.MissionControl.LinksManager")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCopyright("Copyright © HOK Group 2018")]
+[assembly: AssemblyTrademark("Konrad K Sobon")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 //[assembly: AssemblyVersion("2018.0.*")]
-[assembly: AssemblyVersion("2018.0.0.17")]
+[assembly: AssemblyVersion("2018.0.0.18")]
 //[assembly: AssemblyFileVersion("0.0.0.0")]

--- a/Project Monitor/src/HOK.MissionControl/HOK.MissionControl/Properties/AssemblyInfo.cs
+++ b/Project Monitor/src/HOK.MissionControl/HOK.MissionControl/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("HOK Group")]
 [assembly: AssemblyProduct("HOK.MissionControl")]
-[assembly: AssemblyCopyright("Copyright © HOK Group 2016")]
+[assembly: AssemblyCopyright("Copyright © HOK Group 2018")]
 [assembly: AssemblyTrademark("Jinsol Kim, Konrad K Sobon")]
 [assembly: AssemblyCulture("")]
 
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 //[assembly: AssemblyVersion("2018.0.*")]
-[assembly: AssemblyVersion("2018.0.0.17")]
+[assembly: AssemblyVersion("2018.0.0.18")]
 //[assembly: AssemblyFileVersion("2014.0.1.5")]

--- a/Project Monitor/src/HOK.MissionControl/HOK.MissionControl/Tools/WebsiteLink/WebsiteLinkCommand.cs
+++ b/Project Monitor/src/HOK.MissionControl/HOK.MissionControl/Tools/WebsiteLink/WebsiteLinkCommand.cs
@@ -24,8 +24,8 @@ namespace HOK.MissionControl.Tools.WebsiteLink
             {
                 // (Konrad) We are gathering information about the addin use. This allows us to
                 // better maintain the most used plug-ins or discontiue the unused ones.
-                AddinUtilities.PublishAddinLog(new AddinLog("MissionControl-WebsiteLink",
-                    commandData.Application.Application.VersionNumber));
+                var unused1 = AddinUtilities.PublishAddinLog(
+                    new AddinLog("MissionControl-WebsiteLink", commandData.Application.Application.VersionNumber), LogPosted);
 
                 var launchHome = false;
                 var pathName = doc.PathName;
@@ -54,6 +54,12 @@ namespace HOK.MissionControl.Tools.WebsiteLink
 
             Log.AppendLog(LogMessageType.INFO, "Ended");
             return Result.Succeeded;
+        }
+
+        private static void LogPosted(AddinData data)
+        {
+            Log.AppendLog(LogMessageType.INFO, "Addin info was published: " 
+                + (string.IsNullOrEmpty(data.Id) ? "Unsuccessfully." : "Successfully."));
         }
     }
 }


### PR DESCRIPTION
## Description
This updated Mission Control's addin publishing methods to use asynch. It should speed up the UI showing. Right now due to server being slow to respond, it spins for a while before actually showing the UI. That's a bad user experience. 

Solves this: https://github.com/HOKGroup/HOK-Revit-Addins/issues/86
## Tasks
- [x] Submited PR
- [x] Published to BIM Staging
- [x] Tested by David
- [x] Published to BIM Master
