### PR TITLE
update family task assistant to use settings from configuration when …

### DIFF
--- a/HOK.MissionControl/HOK.MissionControl/Tools/Communicator/Tasks/FamilyTaskAssistant/FamilyTaskAssistantModel.cs
+++ b/HOK.MissionControl/HOK.MissionControl/Tools/Communicator/Tasks/FamilyTaskAssistant/FamilyTaskAssistantModel.cs
@@ -1,10 +1,14 @@
-﻿using System;
+﻿#region References
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using HOK.MissionControl.Core.Schemas.Families;
 using HOK.MissionControl.Core.Utils;
 using HOK.MissionControl.Properties;
+
+#endregion
 
 namespace HOK.MissionControl.Tools.Communicator.Tasks.FamilyTaskAssistant
 {
@@ -36,7 +40,7 @@ namespace HOK.MissionControl.Tools.Communicator.Tasks.FamilyTaskAssistant
                 {
                     CheckName = $"Name: {family.Name}",
                     IsCheckPassing = familyNameCheck.Any(family.Name.Contains),
-                    ToolTipText = "Check will fail if Family name does not contain \"_HOK_I\" or \"_HOK_M\"."
+                    ToolTipText = "Check will fail if Family name does not contain " + string.Join(", ", familyNameCheck) + "."
                 },
                 new CheckWrapper
                 {
@@ -54,19 +58,19 @@ namespace HOK.MissionControl.Tools.Communicator.Tasks.FamilyTaskAssistant
                 {
                     CheckName = $"Voids: {family.VoidCount}",
                     IsCheckPassing = family.VoidCount < 5,
-                    ToolTipText = "Check will fail if Family contains more than 5 void cuts."
+                    ToolTipText = "Check will fail if Family contains more than 5 Void Cuts."
                 },
                 new CheckWrapper
                 {
                     CheckName = $"Arrays: {family.ArrayCount}",
                     IsCheckPassing = family.ArrayCount < 5,
-                    ToolTipText = "Check will fail if Family contains more than 5 arrays."
+                    ToolTipText = "Check will fail if Family contains more than 5 Arrays."
                 },
                 new CheckWrapper
                 {
                     CheckName = $"Nested Families: {family.NestedFamilyCount}",
                     IsCheckPassing = family.NestedFamilyCount < 5,
-                    ToolTipText = "Check will fail if Family contains more than 5 nested families."
+                    ToolTipText = "Check will fail if Family contains more than 5 Nested Families."
                 }
             };
 

--- a/HOK.MissionControl/HOK.MissionControl/Tools/Communicator/Tasks/FamilyTaskAssistant/FamilyTaskAssistantViewModel.cs
+++ b/HOK.MissionControl/HOK.MissionControl/Tools/Communicator/Tasks/FamilyTaskAssistant/FamilyTaskAssistantViewModel.cs
@@ -1,4 +1,5 @@
 ﻿#region References
+
 using System.Collections.ObjectModel;
 using System.Reflection;
 using System.Windows;
@@ -8,7 +9,7 @@ using GalaSoft.MvvmLight.Command;
 using GalaSoft.MvvmLight.Messaging;
 using HOK.MissionControl.Core.Schemas.Families;
 using HOK.MissionControl.Tools.Communicator.Messaging;
-using RelayCommand = GalaSoft.MvvmLight.Command.RelayCommand;
+
 #endregion
 
 namespace HOK.MissionControl.Tools.Communicator.Tasks.FamilyTaskAssistant
@@ -24,6 +25,20 @@ namespace HOK.MissionControl.Tools.Communicator.Tasks.FamilyTaskAssistant
         public RelayCommand<Window> WindowLoaded { get; set; }
         public RelayCommand<Window> WindowClosed { get; set; }
         private readonly object _lock = new object();
+
+        private ObservableCollection<CheckWrapper> _checks = new ObservableCollection<CheckWrapper>();
+        public ObservableCollection<CheckWrapper> Checks
+        {
+            get { return _checks; }
+            set { _checks = value; RaisePropertyChanged(() => Checks); }
+        }
+
+        private FamilyTaskWrapper _wrapper;
+        public FamilyTaskWrapper Wrapper
+        {
+            get { return _wrapper; }
+            set { _wrapper = value; RaisePropertyChanged(() => Wrapper); }
+        }
 
         public FamilyTaskAssistantViewModel(FamilyTaskWrapper wrapper)
         {
@@ -74,20 +89,6 @@ namespace HOK.MissionControl.Tools.Communicator.Tasks.FamilyTaskAssistant
         {
             Model.Submit(Wrapper);
             win.Close();
-        }
-
-        private ObservableCollection<CheckWrapper> _checks = new ObservableCollection<CheckWrapper>();
-        public ObservableCollection<CheckWrapper> Checks
-        {
-            get { return _checks; }
-            set { _checks = value; RaisePropertyChanged(() => Checks); }
-        }
-
-        private FamilyTaskWrapper _wrapper;
-        public FamilyTaskWrapper Wrapper
-        {
-            get { return _wrapper; }
-            set { _wrapper = value; RaisePropertyChanged(() => Wrapper); }
         }
 
         #region Message Handlers


### PR DESCRIPTION
## Description
This fixes a small issue where Family Task Assistant was not using Configuration settings for name checks. 

## Tasks
- [x] Submitted PR
- [ ] Published to BIM Staging
- [ ] Tested by David
- [ ] Published to BIM Master
