### PR TITLE
swap out family processing for citrix machines with settings regex check

### DIFF
--- a/HOK.MissionControl/HOK.MissionControl.Core/Schemas/Settings/Settings.cs
+++ b/HOK.MissionControl/HOK.MissionControl.Core/Schemas/Settings/Settings.cs
@@ -1,10 +1,14 @@
-﻿using System.Collections.Generic;
+﻿#region References
+
+using System.Collections.Generic;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
 // ReSharper disable UnusedMember.Global
+
+#endregion
 
 namespace HOK.MissionControl.Core.Schemas.Settings
 {
@@ -35,6 +39,9 @@ namespace HOK.MissionControl.Core.Schemas.Settings
 
         [JsonProperty("projectInfo")]
         public ProjectInfo ProjectInfo { get; set; } = new ProjectInfo();
+
+        [JsonProperty("tempLocation")]
+        public TempLocation TempLocation { get; set; } = new TempLocation();
     }
 
     public class ProjectInfo
@@ -69,12 +76,30 @@ namespace HOK.MissionControl.Core.Schemas.Settings
         public int Group { get; set; }
     }
 
+    public class TempLocation
+    {
+        [JsonProperty("source")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public TempLocationSources Source { get; set; }
+
+        [JsonProperty("pattern")]
+        public string Pattern { get; set; }
+
+        [JsonProperty("tempPath")]
+        public string TempPath { get; set; }
+    }
+
     public enum ProjectInfoSources
     {
         FilePath
     }
 
     public enum UserLocationSources
+    {
+        MachineName
+    }
+
+    public enum TempLocationSources
     {
         MachineName
     }

--- a/HOK.MissionControl/HOK.MissionControl.Core/Utils/AppSettings.cs
+++ b/HOK.MissionControl/HOK.MissionControl.Core/Utils/AppSettings.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
 using HOK.MissionControl.Core.Schemas.Settings;
+// ReSharper disable UnusedMember.Local
 
 namespace HOK.MissionControl.Core.Utils
 {
@@ -10,6 +11,7 @@ namespace HOK.MissionControl.Core.Utils
 
         public List<string> LocalPathRgx { get; set; } = new List<string>();
         public UserLocation UserLocation { get; set; }
+        public TempLocation TempLocation { get; set; }
         public ProjectInfo ProjectInfo { get; set; }
 
         static AppSettings()
@@ -18,6 +20,18 @@ namespace HOK.MissionControl.Core.Utils
 
         private AppSettings()
         {
+        }
+
+        /// <summary>
+        /// Utility for passing Settings properties into the Static class.
+        /// </summary>
+        /// <param name="settings"></param>
+        public void SetSettings(Settings settings)
+        {
+            LocalPathRgx = settings.LocalPathRgx;
+            UserLocation = settings.UserLocation;
+            ProjectInfo = settings.ProjectInfo;
+            TempLocation = settings.TempLocation;
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/HOK.MissionControl/HOK.MissionControl.sln.DotSettings
+++ b/HOK.MissionControl/HOK.MissionControl.sln.DotSettings
@@ -4,6 +4,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=addstyle/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=addtriggerrecord/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=centralpath/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Citrix/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=configid/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=filepaths/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=getmodelsdata/@EntryIndexedValue">True</s:Boolean>

--- a/HOK.MissionControl/HOK.MissionControl/Tools/MissionControl/MissionControl.cs
+++ b/HOK.MissionControl/HOK.MissionControl/Tools/MissionControl/MissionControl.cs
@@ -52,9 +52,7 @@ namespace HOK.MissionControl.Tools.MissionControl
 
                 // (Konrad) Store retrieved settings on the AppSettings class so that they are
                 // publicly available for all tools.
-                AppSettings.Instance.LocalPathRgx = mcSettings.LocalPathRgx;
-                AppSettings.Instance.UserLocation = mcSettings.UserLocation;
-                AppSettings.Instance.ProjectInfo = mcSettings.ProjectInfo;
+                AppSettings.Instance.SetSettings(mcSettings);
 
                 // (Konrad) We can publish a file path to the DB.
                 // That will make it easier to create Configurations.


### PR DESCRIPTION
## Description

This uses global settings to check if user is on a Citrix machine when exporting info about Families. 

## Tasks
- [x] Submitted PR
- [ ] Published to BIM Staging
- [ ] Tested by David
- [ ] Published to BIM Master
