### PR TITLE
DoorUpdate: Handle v1 and v2 Door Parameters

### DIFF
--- a/HOK.MissionControl/HOK.MissionControl/Tools/CADoor/DoorUpdater.cs
+++ b/HOK.MissionControl/HOK.MissionControl/Tools/CADoor/DoorUpdater.cs
@@ -16,8 +16,13 @@ namespace HOK.MissionControl.Tools.CADoor
         private List<Parameter> pullParameters = new List<Parameter>();
         private List<Parameter> pushParameters = new List<Parameter>();
         private List<Parameter> stateCAParameters = new List<Parameter>();
-        private string pullParamName = "Approach @ Pull Side";
-        private string pushParamName = "Approach @ Push Side";
+        private string v1pullParamName = "Approach @ Pull Side";
+        private string v1pushParamName = "Approach @ Push Side";
+        private string v1clearanceTypeName = "Approach";
+        private string v2ParamName = "COMPONENT VERSION";
+        private string v2pullParamName = "CLEARANCE TYPE_ PULL SIDE";
+        private string v2pushParamName = "CLEARANCE TYPE_ PUSH SIDE";
+        private string v2clearanceTypeName = "SWING,";
         private string stateCAParamName = "StateCA";
         private Guid _updaterGuid = new Guid("C2C658D7-EC43-4721-8D2C-2B8C10C340E2");
         public Guid UpdaterGuid { get { return _updaterGuid; } set { _updaterGuid = value; } }
@@ -144,6 +149,10 @@ namespace HOK.MissionControl.Tools.CADoor
                     if (doors.Any())
                     {
                         var doorInstance = doors.First();
+                        bool isV2Door = null != doorInstance.Symbol.LookupParameter(v2ParamName);
+                        string pullParamName = isV2Door ? v2pullParamName : v1pullParamName;
+                        string pushParamName = isV2Door ? v2pushParamName : v1pushParamName;
+                        doorInstance.LookupParameter(v2ParamName);
                         var pullParam = doorInstance.LookupParameter(pullParamName);
                         if (null != pullParam)
                         {
@@ -187,6 +196,10 @@ namespace HOK.MissionControl.Tools.CADoor
                 {
                     var doorId = data.GetModifiedElementIds().First();
                     var doorInstance = doc.GetElement(doorId) as FamilyInstance;
+                    bool isV2Door = null != doorInstance.Symbol.LookupParameter(v2ParamName);
+                    string pullParamName = isV2Door ? v2pullParamName : v1pullParamName;
+                    string pushParamName = isV2Door ? v2pushParamName : v1pushParamName;
+                    string typeNameContains = isV2Door ? v2clearanceTypeName : v1clearanceTypeName;
                     if (null != doorInstance)
                     {
                         var pushParameter = doorInstance.LookupParameter(pushParamName);
@@ -196,7 +209,7 @@ namespace HOK.MissionControl.Tools.CADoor
                             if (data.IsChangeTriggered(doorId, Element.GetChangeTypeParameter(pushParameter)))
                             {
                                 var pushValue = pushParameter.AsValueString();
-                                if (!pushValue.Contains("Approach"))
+                                if (!pushValue.Contains(typeNameContains))
                                 {
                                     DoorFailure.IsDoorFailed = true;
                                     DoorFailure.FailingDoorId = doorId;
@@ -213,7 +226,7 @@ namespace HOK.MissionControl.Tools.CADoor
                             if (data.IsChangeTriggered(doorId, Element.GetChangeTypeParameter(pullParameter)))
                             {
                                 var pullValue = pullParameter.AsValueString();
-                                if (!pullValue.Contains("Approach"))
+                                if (!pullValue.Contains(typeNameContains))
                                 {
                                     DoorFailure.IsDoorFailed = true;
                                     DoorFailure.FailingDoorId = doorId;


### PR DESCRIPTION
## Description
Opening this PR for discussion on this feature. 

Currently, the DoorUpdater monitors any door with the parameters defined by `pushParamName` or `pullParamName` and is hard-coded to do so. HOK updated firm-wide door families that use different parameters for showing clearances.

The first commit on this branch is a minimal change to add monitoring for both old and new doors, but I am exploring ways of making this more generic, allowing for:
* multiple versions of doors
* configuration that is defined by Mission Control

Here is some pseudo-code that may solve the multi-versions bullet point, but I'll admit I'm not familiar enough with C# Collections to make an educated choice between a Hashtable vs a Dictionary vs a Lookup.
```C#
struct doorParams {
  string pushParamName
  string pullParamName
  string clearanceTypeMustContain
}

v1Doors = new doorParams("Approach @ Push Side", "Approach @ Pull Side", "Approach")
v2Doors = new doorParams("CLEARANCE TYPE_ PUSH SIDE", "CLEARANCE TYPE_ PULL SIDE", "SWING,")
Hashtable doorVersions = new Hashtable();
doorVersions.Add("v1", v1Doors);
doorVersions.Add("v2", v2Doors);


string key = isV2door ? "v2" : "v1";
string pushParamName = doorVersions[key].pushParamName;
string pullParamName = doorVersions[key].pullParamName;
string typeNameContains = doorVersions[key].clearanceTypeMustContain;

```