### PR TITLE
fix(MissionControl): Default FilePathItem.IsDisabled to false

### DIFF
--- a/HOK.MissionControl/HOK.MissionControl.Core/Schemas/FilePaths/FilePathItem.cs
+++ b/HOK.MissionControl/HOK.MissionControl.Core/Schemas/FilePaths/FilePathItem.cs
@@ -22,7 +22,7 @@ namespace HOK.MissionControl.Core.Schemas.FilePaths
         public string ProjectId { get; set; }
 
         [JsonProperty("isDisabled")]
-        public bool IsDisabled { get; set; }
+        public bool IsDisabled { get; set; } = false;
 
         [JsonProperty("revitVersion")]
         public string RevitVersion { get; set; } = string.Empty;


### PR DESCRIPTION
## Description
We were running into issues where the `isDisabled` field in [FilePathItem.cs](https://github.com/HOKGroup/HOK-Revit-Addins/blob/master/HOK.MissionControl/HOK.MissionControl.Core/Schemas/FilePaths/FilePathItem.cs#L25) was not being given any value and therefore wasn't showing up in searches and datatables (due to the fact it was explicitly checking for values of `true` or `false`). This just sets the default value to `false` (so not disabled), which can be overwritten by web interface users at a later time.

## Tasks
- [x] Submitted PR
- [ ] Published to BIM Staging
- [ ] Tested by David
- [ ] Published to BIM Master
