### PR TITLE
Implement FME run workspace command using FME v3 REST API + API token

### DIFF
--- a/HOK.Core/HOK.Core/Utilities/Settings.cs
+++ b/HOK.Core/HOK.Core/Utilities/Settings.cs
@@ -13,6 +13,7 @@ namespace HOK.Core.Utilities
         public string ModelReportingServiceEndpoint { get; set; }
         public string FileOnOpeningFmeUserId { get; set; }
         public string FileOnOpeningFmePassword { get; set; }
+        public string FileOnOpeningFmeApiToken { get; set; }
         public string FileOnOpeningFmeHost { get; set; }
         public int FileOnOpeningFmePort { get; set; }
         public string FileOnOpeningFmeClientId { get; set; }

--- a/Utility Tools/src/HOK.FileOnpeningMonitor/HOK.FileOnpeningMonitor/AppCommand.cs
+++ b/Utility Tools/src/HOK.FileOnpeningMonitor/HOK.FileOnpeningMonitor/AppCommand.cs
@@ -61,7 +61,7 @@ namespace HOK.FileOnpeningMonitor
                 var fileInfo = new CentralFileInfo(openedDocument);
                 var unused = new Dictionary<string, string>();
 
-                FMEServerUtil.RunFMEWorkspace(fileInfo, "buildingSMART Notifications", "OpenCentralFileNotification.fmw", out unused);
+                FMEServerUtil.RunFMEWorkspaceHTTP(fileInfo, "buildingSMART Notifications", "OpenCentralFileNotification.fmw", out unused);
 
                 if (!openedCentralFiles.ContainsKey(fileInfo.DocCentralPath))
                 {

--- a/Utility Tools/src/HOK.FileOnpeningMonitor/HOK.FileOnpeningMonitor/FMEServerUtil.cs
+++ b/Utility Tools/src/HOK.FileOnpeningMonitor/HOK.FileOnpeningMonitor/FMEServerUtil.cs
@@ -2,8 +2,10 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Windows;
+using RestSharp;
 using HOK.Core.Utilities;
 using Safe.FMEServer.API;
+using System.Net;
 
 namespace HOK.FileOnpeningMonitor
 {
@@ -11,6 +13,7 @@ namespace HOK.FileOnpeningMonitor
     {
         private static string userId = "";
         private static string password = "";
+        private static string apiToken = "";
         private static string host = "";
         private static int port;
         private static string clientId = "";
@@ -46,6 +49,47 @@ namespace HOK.FileOnpeningMonitor
                     {
                         result = true;
                     }
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Failed to run FME workspace from the FME Server.\n" + ex.Message, "Run FME Workspace", MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
+            return result;
+        }
+
+        public static bool RunFMEWorkspaceHTTP(CentralFileInfo info, string repository, string workspace, out Dictionary<string, string> properties)
+        {
+            var result = false;
+            properties = new Dictionary<string, string>();
+            try
+            {
+                var settingsString = Resources.StreamEmbeddedResource("HOK.Core.Resources.Settings.json");
+                var settings = Json.Deserialize<Settings>(settingsString);
+
+                apiToken = settings.FileOnOpeningFmeApiToken;
+                host = settings.FileOnOpeningFmeHost;
+                var baseUrl = $"http://{host}/fmerest/v3/";
+                var resource = $"transformations/submit/{repository}/{workspace}";
+                var body = new Transformation
+                {
+                    publishedParameters = new List<PublishedParameter>
+                    {
+                        new PublishedParameter { name = "FileName_pp", value = info.DocCentralPath },
+                        new PublishedParameter { name = "Username_pp", value = info.UserName },
+                        new PublishedParameter { name = "Office_pp", value = info.UserLocation }
+                    }
+                };
+
+                var client = new RestClient(baseUrl);
+                var request = new RestRequest(resource, Method.POST);
+                request.AddHeader("Authorization", $"fmetoken token={apiToken}");
+                request.AddJsonBody(body);
+                var response = client.Execute(request);
+
+                if (response.StatusCode == HttpStatusCode.Accepted)
+                {
+                    result = true;
                 }
             }
             catch (Exception ex)

--- a/Utility Tools/src/HOK.FileOnpeningMonitor/HOK.FileOnpeningMonitor/FMEWrappers.cs
+++ b/Utility Tools/src/HOK.FileOnpeningMonitor/HOK.FileOnpeningMonitor/FMEWrappers.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HOK.FileOnpeningMonitor
+{
+    public class Transformation
+    {
+        public List<PublishedParameter> publishedParameters { get; set; }
+        public TmDirectives tmDirectives { get; set; }
+        public List<NmDirective> nmDirectives { get; set; }
+    } 
+
+    public class PublishedParameter
+    {
+        public string name;
+        public string value;
+    }
+
+    public class TmDirectives
+    {
+        public bool rtc { get; set; }
+        public int ttc { get; set; }
+        public int ttl { get; set; }
+        public string tag { get; set; }
+    }
+
+    public class NmDirective
+    {
+        public List<object> directives { get; set; }
+        public List<string> successTopics { get; set; }
+        public List<string> failureTopics { get; set; }
+    }
+}

--- a/Utility Tools/src/HOK.FileOnpeningMonitor/HOK.FileOnpeningMonitor/HOK.FileOnpeningMonitor.csproj
+++ b/Utility Tools/src/HOK.FileOnpeningMonitor/HOK.FileOnpeningMonitor/HOK.FileOnpeningMonitor.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -154,6 +154,9 @@
       <HintPath>..\..\..\..\HOK.MissionControl\HOK.MissionControl.Core\bin\2020\HOK.MissionControl.Core.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+    <Reference Include="RestSharp, Version=106.0.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.10.1\lib\net452\RestSharp.dll</HintPath>
+    </Reference>
     <Reference Include="RevitAPI" Condition=" '$(Configuration)' == '2015'">
       <HintPath>..\..\..\..\..\..\..\..\..\..\Program Files\Autodesk\Revit 2015\RevitAPI.dll</HintPath>
       <Private>False</Private>
@@ -214,6 +217,7 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
@@ -230,6 +234,7 @@
       <DependentUpon>CentralFileWarningWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="FMEServerUtil.cs" />
+    <Compile Include="FMEWrappers.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TimedWarningWindow.xaml.cs">
       <DependentUpon>TimedWarningWindow.xaml</DependentUpon>
@@ -272,6 +277,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Utility Tools/src/HOK.FileOnpeningMonitor/HOK.FileOnpeningMonitor/app.config
+++ b/Utility Tools/src/HOK.FileOnpeningMonitor/HOK.FileOnpeningMonitor/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="RestSharp" publicKeyToken="598062e77f915f75" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-106.0.0.0" newVersion="106.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Utility Tools/src/HOK.FileOnpeningMonitor/HOK.FileOnpeningMonitor/packages.config
+++ b/Utility Tools/src/HOK.FileOnpeningMonitor/HOK.FileOnpeningMonitor/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="Costura.Fody" version="2.0.1" targetFramework="net471" />
   <package id="Fody" version="3.0.3" targetFramework="net471" developmentDependency="true" />
+  <package id="RestSharp" version="106.10.1" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
## Description
The FME .NET library is woefully out of date and not documented on their site, so this change implements the [FMEServer REST API v3](https://docs.safe.com/fme/html/FME_REST/apidoc/v3/index.html) for running the workspace. 

It allows allows us to use an access token instead of a password, so once this is deployed we can close #172 