### PR TITLE
fix(MissionControl): Update BIM360 -> Cloud model

### DIFF
--- a/HOK.MissionControl/HOK.MissionControl.Core/Schemas/FilePaths/FilePathItem.cs
+++ b/HOK.MissionControl/HOK.MissionControl.Core/Schemas/FilePaths/FilePathItem.cs
@@ -81,7 +81,7 @@ namespace HOK.MissionControl.Core.Schemas.FilePaths
                         else if (AppSettings.Instance.LocalPathRgx.Any(x =>
                             Regex.IsMatch(CentralPath, x, RegexOptions.IgnoreCase)))
                             key = "local";
-                        else if (CentralPath.Contains("://", StringComparison.OrdinalIgnoreCase))
+                        else if (CentralPath.Contains("://"))
                             key = "bimThreeSixty";
                         else return;
 
@@ -154,7 +154,7 @@ namespace HOK.MissionControl.Core.Schemas.FilePaths
             {
                 result = true;
             }
-            else if (!isRevitServer && centralPath.Contains("://", StringComparison.OrdinalIgnoreCase))
+            else if (!isRevitServer && centralPath.Contains("://"))
             {
                 result = true;
             }

--- a/HOK.MissionControl/HOK.MissionControl.Core/Schemas/FilePaths/FilePathItem.cs
+++ b/HOK.MissionControl/HOK.MissionControl.Core/Schemas/FilePaths/FilePathItem.cs
@@ -81,7 +81,7 @@ namespace HOK.MissionControl.Core.Schemas.FilePaths
                         else if (AppSettings.Instance.LocalPathRgx.Any(x =>
                             Regex.IsMatch(CentralPath, x, RegexOptions.IgnoreCase)))
                             key = "local";
-                        else if (CentralPath.StartsWith("bim 360://", StringComparison.OrdinalIgnoreCase))
+                        else if (CentralPath.Contains("://", StringComparison.OrdinalIgnoreCase))
                             key = "bimThreeSixty";
                         else return;
 
@@ -138,14 +138,15 @@ namespace HOK.MissionControl.Core.Schemas.FilePaths
         }
 
         /// <summary>
-        /// Validates a file path, making sure that its either a revit server file, bim 360 or hok network location.
+        /// Validates a file path, making sure that its either a revit server file, cloud model or hok network location.
         /// </summary>
         /// <param name="centralPath">Central Path to validate.</param>
         /// <returns>True if file path is valid, otherwise false.</returns>
         public static bool IsValidFilePath(string centralPath)
         {
             var result = false;
-            if (centralPath.StartsWith("rsn://", StringComparison.OrdinalIgnoreCase))
+            bool isRevitServer = centralPath.StartsWith("rsn://", StringComparison.OrdinalIgnoreCase);
+            if (isRevitServer)
             {
                 result = true;
             }
@@ -153,7 +154,7 @@ namespace HOK.MissionControl.Core.Schemas.FilePaths
             {
                 result = true;
             }
-            else if (centralPath.StartsWith("bim 360://", StringComparison.OrdinalIgnoreCase))
+            else if (!isRevitServer && centralPath.Contains("://", StringComparison.OrdinalIgnoreCase))
             {
                 result = true;
             }

--- a/HOK.MissionControl/HOK.MissionControl/Tools/HealthReport/ModelMonitor.cs
+++ b/HOK.MissionControl/HOK.MissionControl/Tools/HealthReport/ModelMonitor.cs
@@ -86,7 +86,8 @@ namespace HOK.MissionControl.Tools.HealthReport
                 long fileSize;
                 try
                 {
-                    if (filePath.StartsWith("rsn://", StringComparison.OrdinalIgnoreCase))
+                    bool isRevitServer = filePath.StartsWith("rsn://", StringComparison.OrdinalIgnoreCase);
+                    if (isRevitServer)
                     {
                         var server = string.Empty;
                         var subfolder = string.Empty;
@@ -106,7 +107,7 @@ namespace HOK.MissionControl.Tools.HealthReport
                         var result = ServerUtilities.GetFileInfoFromRevitServer<RsFileInfo>(clientPath, requestPath);
                         fileSize = result.ModelSize - result.SupportSize;
                     }
-                    else if (filePath.StartsWith("bim 360://", StringComparison.OrdinalIgnoreCase))
+                    else if (!isRevitServer && filePath.Contains("://", StringComparison.OrdinalIgnoreCase))
                     {
                         // (Konrad) For BIM 360 files, we can just pull the file size from local cached file.
                         // It's pretty much what is stored in the web, so will work for our purpose.

--- a/HOK.MissionControl/HOK.MissionControl/Tools/HealthReport/ModelMonitor.cs
+++ b/HOK.MissionControl/HOK.MissionControl/Tools/HealthReport/ModelMonitor.cs
@@ -107,7 +107,7 @@ namespace HOK.MissionControl.Tools.HealthReport
                         var result = ServerUtilities.GetFileInfoFromRevitServer<RsFileInfo>(clientPath, requestPath);
                         fileSize = result.ModelSize - result.SupportSize;
                     }
-                    else if (!isRevitServer && filePath.Contains("://", StringComparison.OrdinalIgnoreCase))
+                    else if (!isRevitServer && filePath.Contains("://"))
                     {
                         // (Konrad) For BIM 360 files, we can just pull the file size from local cached file.
                         // It's pretty much what is stored in the web, so will work for our purpose.

--- a/HOK.MissionControl/HOK.MissionControl/Tools/MissionControl/MissionControl.cs
+++ b/HOK.MissionControl/HOK.MissionControl/Tools/MissionControl/MissionControl.cs
@@ -60,7 +60,7 @@ namespace HOK.MissionControl.Tools.MissionControl
                 // - not detached
                 // - not a family
                 // - is work-shared
-                // - is saved on the network, revit server or bim 360 server
+                // - is saved on the network, revit server or a cloud model
                 if (!doc.IsDetached && !doc.IsFamilyDocument && doc.IsWorkshared && FilePathItem.IsValidFilePath(centralPath))
                 {
                     if (!ServerUtilities.Post(new FilePathItem(centralPath, doc.Application.VersionNumber), "filepaths/add", out FilePathItem unused))

--- a/_build/copy_resources.ps1
+++ b/_build/copy_resources.ps1
@@ -23,7 +23,7 @@ $msg = "Copying {0} to {1}" -f $p,$d
 Write-Debug $msg
 Copy-Item $p -Destination $d
 
-$p = ".\Smart BCF\src\HOK.SmartBCF\HOK.SmartBCF.AddIn\bin\{0}\x86\ " -f $buildConfiguration
-Copy-Item -Path $p -Destination $libraryFolder -Filter '*.dll' -Container -Recurse
-$p = ".\Smart BCF\src\HOK.SmartBCF\HOK.SmartBCF.AddIn\bin\{0}\x64\ " -f $buildConfiguration
-Copy-Item -Path $p -Destination $libraryFolder -Filter '*.dll' -Container -Recurse
+$p = ".\Smart BCF\src\HOK.SmartBCF\HOK.SmartBCF.Manager\x86"
+Copy-Item -Path $p -Destination $libraryFolder -Recurse
+$p = ".\Smart BCF\src\HOK.SmartBCF\HOK.SmartBCF.Manager\x64"
+Copy-Item -Path $p -Destination $libraryFolder -Recurse

--- a/_build/resources.csv
+++ b/_build/resources.csv
@@ -1,11 +1,5 @@
 ﻿sourcePath,fileName,destination
 Smart BCF\src\HOK.SmartBCF\HOK.SmartBCF.AddIn\Resources,Addins Shared Parameters.txt,HOK-Addin.bundle\Contents\Resources\
-Data Editor\src\HOK.RevitDBManager\RevitDBManager\Resources,default.bmp,HOK-Addin.bundle\Contents\Resources\
-AVF Manager\src\HOK.AVFManager\HOK.AVFManager\Resources,DefaultSettings.xml,HOK-Addin.bundle\Contents\Resources\
-Data Editor\src\HOK.RevitDBManager\RevitDBManager\Resources,eye.ico,HOK-Addin.bundle\Contents\Resources\
 Navigator\src\HOK.Navigator\HOK.Navigator\Resources,HOK.Help.txt,HOK-Addin.bundle\Contents\Resources\
 Navigator\src\HOK.Navigator\HOK.Navigator\Resources,HOK.Installer.txt,HOK-Addin.bundle\Contents\Resources\
 HOK.RibbonTab\HOK.RibbonTab\Resources,HOK.Tooltip.txt,HOK-Addin.bundle\Contents\Resources\
-BCF Reader\src\HOK.SmartBCF\HOK.SmartBCF\BCFClasses,markup.xsd,HOK-Addin.bundle\Contents\Resources\
-AVF Manager\src\HOK.AVFManager\HOK.AVFManager\Resources,PointOfView.rfa,HOK-Addin.bundle\Contents\Resources\
-BCF Reader\src\HOK.SmartBCF\HOK.SmartBCF\BCFClasses,visinfo.xsd,HOK-Addin.bundle\Contents\Resources\

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,8 +23,6 @@ strategy:
       buildConfiguration: '2020'
     2019:
       buildConfiguration: '2019'
-    2018:
-      buildConfiguration: '2018'
 
 pool:
   vmImage: 'windows-latest'


### PR DESCRIPTION
These changes reflect changes made to Mission Control, where any reference to BIM 360 is replaced with "Cloud Model" and a more generic filepath test is used to account for multiple 'protocols' at the beginning of the filepath (BIM 360://, Autodesk Docs://, ACC://, etc) that aren't RSN://
