### PR TITLE
0.1.0.28: Fix RestSharp issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # Settings file that is specific to each user/organization
 HOK.Core\HOK.Core\Resources\Settings.json
+HOK.MissionControl\nuget.config
 
 # Build results
 [Dd]ebug/

--- a/HOK.AddInManager/HOK.AddInManager/HOK.AddInManager.csproj
+++ b/HOK.AddInManager/HOK.AddInManager/HOK.AddInManager.csproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.AddInManager/HOK.DesktopConnectorLauncher/HOK.DesktopConnectorLauncher.csproj
+++ b/HOK.AddInManager/HOK.DesktopConnectorLauncher/HOK.DesktopConnectorLauncher.csproj
@@ -17,7 +17,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.Core/HOK.Core/HOK.Core.csproj
+++ b/HOK.Core/HOK.Core/HOK.Core.csproj
@@ -16,7 +16,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.ElementFlatter/HOK.ElementFlatter/HOK.ElementFlatter.csproj
+++ b/HOK.ElementFlatter/HOK.ElementFlatter/HOK.ElementFlatter.csproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.ElementMover/HOK.ElementMover/HOK.ElementMover.csproj
+++ b/HOK.ElementMover/HOK.ElementMover/HOK.ElementMover.csproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.ElementTools/HOK.ElementTools/HOK.ElementTools.vbproj
+++ b/HOK.ElementTools/HOK.ElementTools/HOK.ElementTools.vbproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
     <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
   </PropertyGroup>
 

--- a/HOK.Feedback/HOK.Feedback/HOK.Feedback.csproj
+++ b/HOK.Feedback/HOK.Feedback/HOK.Feedback.csproj
@@ -19,7 +19,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.FileOpeningMonitor/HOK.FileOpeningMonitor/HOK.FileOpeningMonitor.csproj
+++ b/HOK.FileOpeningMonitor/HOK.FileOpeningMonitor/HOK.FileOpeningMonitor.csproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.LPDCalculator/HOK.LPDCalculator/HOK.LPDCalculator.csproj
+++ b/HOK.LPDCalculator/HOK.LPDCalculator/HOK.LPDCalculator.csproj
@@ -19,7 +19,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.MissionControl/HOK.MissionControl.Core/HOK.MissionControl.Core.csproj
+++ b/HOK.MissionControl/HOK.MissionControl.Core/HOK.MissionControl.Core.csproj
@@ -74,7 +74,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Nice3point.Revit.Build.Tasks" Version="2.0.2" />
-    <PackageReference Include="RestSharp" Version="112.1.0" />
+    <PackageReference Include="HOK_RestSharp" Version="112.1.0" />
     <PackageReference Include="MongoDB.Bson" Version="2.29.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
@@ -83,7 +83,7 @@
   <ItemGroup>
     <PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="$(RevitVersion).*" />
     <PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="$(RevitVersion).*" />
-    <PackageReference Include="Nice3point.Revit.Toolkit" Version="$(RevitVersion).*-*"/>
+    <PackageReference Include="Nice3point.Revit.Toolkit" Version="$(RevitVersion).*-*" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">

--- a/HOK.MissionControl/HOK.MissionControl.Core/HOK.MissionControl.Core.csproj
+++ b/HOK.MissionControl/HOK.MissionControl.Core/HOK.MissionControl.Core.csproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.MissionControl/HOK.MissionControl.Core/Utils/ServerUtilities.cs
+++ b/HOK.MissionControl/HOK.MissionControl.Core/Utils/ServerUtilities.cs
@@ -24,8 +24,12 @@ namespace HOK.MissionControl.Core.Utils
 
         static ServerUtilities()
         {
-            var settingsString = Resources.StreamEmbeddedResource("HOK.Core.Resources.Settings.json");
-            RestApiBaseUrl = Json.Deserialize<HOK.Core.Utilities.Settings>(settingsString)?.HttpAddress; //production
+            var settingsString = Resources.StreamEmbeddedResource(
+                "HOK.Core.Resources.Settings.json"
+            );
+            RestApiBaseUrl = Json.Deserialize<HOK.Core.Utilities.Settings>(
+                settingsString
+            )?.HttpAddress; //production
             //RestApiBaseUrl = Json.Deserialize<Settings>(settingsString)?.HttpAddressDebug; //debug
             Settings = Json.Deserialize<HOK.Core.Utilities.Settings>(settingsString);
         }
@@ -33,13 +37,14 @@ namespace HOK.MissionControl.Core.Utils
         #region GET
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="path"></param>
         /// <param name="result"></param>
         /// <returns></returns>
-        public static bool GetOne<T>(string path, out T result) where T : new()
+        public static bool GetOne<T>(string path, out T result)
+            where T : new()
         {
             result = default(T);
             try
@@ -47,7 +52,8 @@ namespace HOK.MissionControl.Core.Utils
                 var client = new RestClient(RestApiBaseUrl);
                 var request = new RestRequest(ApiVersion + "/" + path, Method.Get);
                 var response = client.Execute(request);
-                if (response.StatusCode != HttpStatusCode.OK) return false;
+                if (response.StatusCode != HttpStatusCode.OK)
+                    return false;
 
                 if (!string.IsNullOrWhiteSpace(response.Content))
                 {
@@ -58,7 +64,10 @@ namespace HOK.MissionControl.Core.Utils
                         return true;
                     }
 
-                    Log.AppendLog(LogMessageType.ERROR, "Could not find a document matching the query.");
+                    Log.AppendLog(
+                        LogMessageType.ERROR,
+                        "Could not find a document matching the query."
+                    );
                 }
 
                 return false;
@@ -77,7 +86,8 @@ namespace HOK.MissionControl.Core.Utils
         /// <param name="path">HTTP request url.</param>
         /// <param name="result">Resulting Asset.</param>
         /// <returns>True if success, otherwise false.</returns>
-        public static bool Get<T>(string path, out T result) where T : new()
+        public static bool Get<T>(string path, out T result)
+            where T : new()
         {
             result = default(T);
             try
@@ -85,7 +95,8 @@ namespace HOK.MissionControl.Core.Utils
                 var client = new RestClient(RestApiBaseUrl);
                 var request = new RestRequest(ApiVersion + "/" + path, Method.Get);
                 var response = client.Execute(request);
-                if (response.StatusCode != HttpStatusCode.OK) return false;
+                if (response.StatusCode != HttpStatusCode.OK)
+                    return false;
 
                 if (!string.IsNullOrWhiteSpace(response.Content))
                 {
@@ -96,7 +107,10 @@ namespace HOK.MissionControl.Core.Utils
                         return true;
                     }
 
-                    Log.AppendLog(LogMessageType.ERROR, "Could not find a document matching the query.");
+                    Log.AppendLog(
+                        LogMessageType.ERROR,
+                        "Could not find a document matching the query."
+                    );
                 }
 
                 return false;
@@ -115,7 +129,8 @@ namespace HOK.MissionControl.Core.Utils
         /// <param name="path">HTTP request url.</param>
         /// <param name="result"></param>
         /// <returns>Document if found matching central path or type.</returns>
-        public static bool GetByCentralPath<T>(string centralPath, string path, out T result) where T : new()
+        public static bool GetByCentralPath<T>(string centralPath, string path, out T result)
+            where T : new()
         {
             result = new T();
             try
@@ -124,11 +139,16 @@ namespace HOK.MissionControl.Core.Utils
                 // Since pipe cannot be used in a legal file path, it's a good placeholder to use.
                 // File path can also contain forward slashes for RSN and BIM 360 paths ex: RSN:// and BIM 360://
                 string filePath;
-                if (centralPath.Contains(@"\")) filePath = centralPath.Replace(@"\", "|");
-                else if (centralPath.Contains(@"/")) filePath = centralPath.Replace(@"/", "|");
+                if (centralPath.Contains(@"\"))
+                    filePath = centralPath.Replace(@"\", "|");
+                else if (centralPath.Contains(@"/"))
+                    filePath = centralPath.Replace(@"/", "|");
                 else
                 {
-                    Log.AppendLog(LogMessageType.ERROR, "Could not replace \\ or / with | in the file path. Exiting.");
+                    Log.AppendLog(
+                        LogMessageType.ERROR,
+                        "Could not replace \\ or / with | in the file path. Exiting."
+                    );
                     return false;
                 }
 
@@ -138,7 +158,8 @@ namespace HOK.MissionControl.Core.Utils
                 request.RequestFormat = DataFormat.Json;
 
                 var response = client.Execute(request);
-                if (response.StatusCode != HttpStatusCode.OK) return false;
+                if (response.StatusCode != HttpStatusCode.OK)
+                    return false;
                 if (!string.IsNullOrEmpty(response.Content))
                 {
                     var data = Json.Deserialize<List<T>>(response.Content).FirstOrDefault();
@@ -148,7 +169,10 @@ namespace HOK.MissionControl.Core.Utils
                         return true;
                     }
 
-                    Log.AppendLog(LogMessageType.ERROR, "Could not find a document with matching central path.");
+                    Log.AppendLog(
+                        LogMessageType.ERROR,
+                        "Could not find a document with matching central path."
+                    );
                 }
                 return false;
             }
@@ -168,7 +192,8 @@ namespace HOK.MissionControl.Core.Utils
         /// </summary>
         /// <param name="body"></param>
         /// <param name="route"></param>
-        public static bool Put<T>(T body, string route) where T : class
+        public static bool Put<T>(T body, string route)
+            where T : class
         {
             try
             {
@@ -184,7 +209,7 @@ namespace HOK.MissionControl.Core.Utils
                     Log.AppendLog(LogMessageType.INFO, response.ResponseStatus + route);
                     return false;
                 }
-                
+
                 return true;
             }
             catch (Exception ex)
@@ -201,7 +226,8 @@ namespace HOK.MissionControl.Core.Utils
         /// <param name="body">Body of rest call.</param>
         /// <param name="route">Route to be called.</param>
         /// <returns>Newly created Collection Schema with MongoDB assigned Id.</returns>
-        public static async Task<T> PostAsync<T>(object body, string route) where T : new()
+        public static async Task<T> PostAsync<T>(object body, string route)
+            where T : new()
         {
             var client = new RestClient(RestApiBaseUrl);
 
@@ -209,27 +235,35 @@ namespace HOK.MissionControl.Core.Utils
             request.RequestFormat = DataFormat.Json;
             request.AddJsonBody(body);
 
-            var response = await client.ExecuteAsync<T>(request);
+            var response = await client.ExecuteAsync(request);
             if (response.StatusCode != HttpStatusCode.Created)
             {
                 Log.AppendLog(LogMessageType.EXCEPTION, response.StatusDescription);
                 return new T();
             }
 
+            if (!string.IsNullOrEmpty(response.Content))
+            {
+                var data = Json.Deserialize<T>(response.Content);
+                if (data != null)
+                {
+                    return data;
+                }
+            }
             Log.AppendLog(LogMessageType.INFO, response.StatusDescription + "-" + route);
-            return response.Data;
+            return new T();
         }
 
-
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="body"></param>
         /// <param name="route"></param>
         /// <param name="result"></param>
         /// <returns></returns>
-        public static bool Post<T>(object body, string route, out T result) where T : new()
+        public static bool Post<T>(object body, string route, out T result)
+            where T : new()
         {
             result = default(T);
             try
@@ -240,12 +274,17 @@ namespace HOK.MissionControl.Core.Utils
                 request.RequestFormat = DataFormat.Json;
                 request.AddJsonBody(body);
 
-                var response = client.Execute<T>(request);
-                if (response.StatusCode != HttpStatusCode.Created) return false;
-                if (response.Data != null)
+                var response = client.Execute(request);
+                if (response.StatusCode != HttpStatusCode.Created)
+                    return false;
+                if (!string.IsNullOrEmpty(response.Content))
                 {
-                    result = response.Data;
-                    return true;
+                    var data = Json.Deserialize<T>(response.Content);
+                    if (data != null)
+                    {
+                        result = data;
+                        return true;
+                    }
                 }
                 return false;
             }
@@ -266,7 +305,8 @@ namespace HOK.MissionControl.Core.Utils
         /// <param name="clientPath">Base URL to the Revit Server.</param>
         /// <param name="requestPath">Request string.</param>
         /// <returns>File size in bytes.</returns>
-        public static T GetFileInfoFromRevitServer<T>(string clientPath, string requestPath) where T : new()
+        public static T GetFileInfoFromRevitServer<T>(string clientPath, string requestPath)
+            where T : new()
         {
             var result = default(T);
             try
@@ -276,14 +316,17 @@ namespace HOK.MissionControl.Core.Utils
                 request.AddHeader("User-Name", Environment.UserName);
                 request.AddHeader("Operation-GUID", Guid.NewGuid().ToString());
                 string[] clarityServers = Settings.ClarityServers;
-                if (clarityServers.Any(clientPath.Contains)) {
+                if (clarityServers.Any(clientPath.Contains))
+                {
                     string clarityId = Settings.ClarityUserId;
                     request.AddHeader("ClarityUserId", clarityId);
                     string securityToken = Settings.ClarityToken;
                     request.AddHeader("SecurityToken", securityToken);
                     string clarityMachine = Settings.ClarityMachine;
-                    request.AddHeader("User-Machine-Name", clarityMachine); 
-                } else {
+                    request.AddHeader("User-Machine-Name", clarityMachine);
+                }
+                else
+                {
                     request.AddHeader("User-Machine-Name", Environment.UserName + "PC");
                 }
 

--- a/HOK.MissionControl/HOK.MissionControl.FamilyPublish/HOK.MissionControl.FamilyPublish.csproj
+++ b/HOK.MissionControl/HOK.MissionControl.FamilyPublish/HOK.MissionControl.FamilyPublish.csproj
@@ -19,7 +19,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.MissionControl/HOK.MissionControl.GroupsManager/HOK.MissionControl.GroupsManager.csproj
+++ b/HOK.MissionControl/HOK.MissionControl.GroupsManager/HOK.MissionControl.GroupsManager.csproj
@@ -19,7 +19,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.MissionControl/HOK.MissionControl.LinksManager/HOK.MissionControl.LinksManager.csproj
+++ b/HOK.MissionControl/HOK.MissionControl.LinksManager/HOK.MissionControl.LinksManager.csproj
@@ -19,7 +19,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.MissionControl/HOK.MissionControl.StylesManager/HOK.MissionControl.StylesManager.csproj
+++ b/HOK.MissionControl/HOK.MissionControl.StylesManager/HOK.MissionControl.StylesManager.csproj
@@ -19,7 +19,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.MissionControl/HOK.MissionControl/AppCommand.cs
+++ b/HOK.MissionControl/HOK.MissionControl/AppCommand.cs
@@ -15,7 +15,6 @@ using HOK.MissionControl.Tools.Communicator;
 using HOK.MissionControl.Tools.DTMTool;
 using HOK.MissionControl.Core.Utils;
 using HOK.MissionControl.Tools.Communicator.Messaging;
-using HOK.MissionControl.Tools.Communicator.Socket;
 using HOK.MissionControl.Tools.MissionControl;
 using Nice3point.Revit.Toolkit.External;
 
@@ -32,7 +31,6 @@ namespace HOK.MissionControl
         public static Dictionary<string, DateTime> OpenTime { get; set; } = new Dictionary<string, DateTime>();
         public static Dictionary<string, WarningItem> Warnings { get; set; } = new Dictionary<string, WarningItem>();
         public static CommunicatorView CommunicatorWindow { get; set; }
-        public static MissionControlSocket Socket { get; set; }
         public static bool IsSynching { get; set; }
         public static bool IsSynchOverriden { get; set; }
         public static bool IsSynchNowOverriden { get; set; }
@@ -154,11 +152,6 @@ namespace HOK.MissionControl
 
                 // (Konrad) Cleanup updaters.
                 Tools.MissionControl.MissionControl.UnregisterUpdaters(doc);
-
-                // (Konrad) Disconnect from Sockets.
-                Socket?.Kill();
-
-                // (Konrad) If any task windows are still open, let's shut them down.
             }
             catch (Exception ex)
             {

--- a/HOK.MissionControl/HOK.MissionControl/HOK.MissionControl.csproj
+++ b/HOK.MissionControl/HOK.MissionControl/HOK.MissionControl.csproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.MissionControl/HOK.MissionControl/HOK.MissionControl.csproj
+++ b/HOK.MissionControl/HOK.MissionControl/HOK.MissionControl.csproj
@@ -116,7 +116,7 @@
   <ItemGroup>
     <PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="$(RevitVersion).*" />
     <PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="$(RevitVersion).*" />
-    <PackageReference Include="Nice3point.Revit.Toolkit" Version="$(RevitVersion).*-*"/>
+    <PackageReference Include="Nice3point.Revit.Toolkit" Version="$(RevitVersion).*-*" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">

--- a/HOK.MissionControl/HOK.MissionControl/Tools/MissionControl/MissionControl.cs
+++ b/HOK.MissionControl/HOK.MissionControl/Tools/MissionControl/MissionControl.cs
@@ -24,7 +24,6 @@ using HOK.MissionControl.Core.Schemas.Worksets;
 using HOK.MissionControl.Core.Utils;
 using HOK.MissionControl.Tools.Communicator;
 using HOK.MissionControl.Tools.Communicator.Messaging;
-using HOK.MissionControl.Tools.Communicator.Socket;
 using HOK.MissionControl.Tools.HealthReport;
 using HOK.MissionControl.Utils;
 
@@ -116,7 +115,6 @@ namespace HOK.MissionControl.Tools.MissionControl
             {
                 var centralPath = FileInfoUtil.GetCentralFilePath(doc);
                 var config = MissionControlSetup.Configurations[centralPath];
-                var launchSockets = false;
                 foreach (var updater in config.Updaters)
                 {
                     if (!updater.IsUpdaterOn) continue;
@@ -156,7 +154,6 @@ namespace HOK.MissionControl.Tools.MissionControl
                         {
                             ProcessSheets(ActionType.CheckIn, doc, centralPath);
 
-                            launchSockets = true;
                         }
                         else if (string.Equals(updater.UpdaterId, Properties.Resources.HealthReportTrackerGuid,
                             StringComparison.OrdinalIgnoreCase))
@@ -170,8 +167,6 @@ namespace HOK.MissionControl.Tools.MissionControl
                             ProcessLinks(doc, centralPath);
                             ProcessViews(doc, centralPath);
                             ProcessGroups(doc, centralPath);
-
-                            launchSockets = true;
                         }
                     }
                     catch (Exception ex)
@@ -193,15 +188,6 @@ namespace HOK.MissionControl.Tools.MissionControl
                     {
                         Log.AppendLog(LogMessageType.ERROR, "Failed to reset Shared Parameter location. Could not find file specified.");
                     }
-                }
-
-                if (launchSockets)
-                {
-                    // (Konrad) in order not to become out of synch with the database we need a way
-                    // to communicate live updates from the database to task assistant/communicator
-                    var socket = new MissionControlSocket(doc);
-                    socket.Start();
-                    AppCommand.Socket = socket;
                 }
 
                 // Publish user/machine info to be used by Zombie

--- a/HOK.MissionControl/SharedAssemblyInfo.cs
+++ b/HOK.MissionControl/SharedAssemblyInfo.cs
@@ -18,5 +18,5 @@ using System.Reflection;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("2025.1.0.26")]
-[assembly: AssemblyFileVersion("2025.1.0.26")]
+[assembly: AssemblyVersion("2025.1.0.28")]
+[assembly: AssemblyFileVersion("2025.1.0.28")]

--- a/HOK.MoveBackup/HOK.MoveBackup/HOK.MoveBackup.csproj
+++ b/HOK.MoveBackup/HOK.MoveBackup/HOK.MoveBackup.csproj
@@ -17,7 +17,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.Navigator/HOK.Navigator/HOK.Navigator.csproj
+++ b/HOK.Navigator/HOK.Navigator/HOK.Navigator.csproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.ParameterTools/HOK.ParameterTools/HOK.ParameterTools.vbproj
+++ b/HOK.ParameterTools/HOK.ParameterTools/HOK.ParameterTools.vbproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.RibbonTab/HOK.RibbonTab/HOK.RibbonTab.csproj
+++ b/HOK.RibbonTab/HOK.RibbonTab/HOK.RibbonTab.csproj
@@ -84,13 +84,6 @@
     <None Remove="Resources\colorBasedIssueFinder_32.png" />
   </ItemGroup>
 
-  <!-- Revit APIs -->
-  <ItemGroup>
-    <PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="$(RevitVersion).*" />
-    <PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="$(RevitVersion).*" />
-    <PackageReference Include="Nice3point.Revit.Toolkit" Version="$(RevitVersion).*-*" />
-  </ItemGroup>
-
   <ItemGroup>
     <EmbeddedResource Include="Resources\colorBasedIssueFinder_32.png" />
     <EmbeddedResource Include="Resources\parameter.ico" />

--- a/HOK.RibbonTab/HOK.RibbonTab/HOK.RibbonTab.csproj
+++ b/HOK.RibbonTab/HOK.RibbonTab/HOK.RibbonTab.csproj
@@ -17,7 +17,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.RoomsToMass/HOK.RoomsToMass/HOK.RoomsToMass.csproj
+++ b/HOK.RoomsToMass/HOK.RoomsToMass/HOK.RoomsToMass.csproj
@@ -19,7 +19,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.SheetManager/SheetManager/HOK.SheetManager.vbproj
+++ b/HOK.SheetManager/SheetManager/HOK.SheetManager.vbproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.Utilities/HOK.Arrowhead/HOK.Arrowhead.csproj
+++ b/HOK.Utilities/HOK.Arrowhead/HOK.Arrowhead.csproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.Utilities/HOK.CameraDuplicator/HOK.CameraDuplicator.csproj
+++ b/HOK.Utilities/HOK.CameraDuplicator/HOK.CameraDuplicator.csproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.Utilities/HOK.CeilingHeight/HOK.CeilingHeight.csproj
+++ b/HOK.Utilities/HOK.CeilingHeight/HOK.CeilingHeight.csproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.Utilities/HOK.ColorBasedIssueFinder/HOK.ColorBasedIssueFinder.csproj
+++ b/HOK.Utilities/HOK.ColorBasedIssueFinder/HOK.ColorBasedIssueFinder.csproj
@@ -26,7 +26,7 @@
     <Company>Autodesk Inc.</Company>
     <Product>HOK.ColorBasedIssueFinder Revit C# .NET Add-In</Product>
     <Copyright>Copyright © HOK Group 2025</Copyright>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.Utilities/HOK.DoorRoom/HOK.DoorRoom.csproj
+++ b/HOK.Utilities/HOK.DoorRoom/HOK.DoorRoom.csproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.Utilities/HOK.FinishCreator/HOK.FinishCreator.csproj
+++ b/HOK.Utilities/HOK.FinishCreator/HOK.FinishCreator.csproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.Utilities/HOK.LevelManager/HOK.LevelManager.csproj
+++ b/HOK.Utilities/HOK.LevelManager/HOK.LevelManager.csproj
@@ -19,7 +19,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.Utilities/HOK.RenameFamily/HOK.RenameFamily.csproj
+++ b/HOK.Utilities/HOK.RenameFamily/HOK.RenameFamily.csproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.Utilities/HOK.RoomElevation/HOK.RoomElevation.csproj
+++ b/HOK.Utilities/HOK.RoomElevation/HOK.RoomElevation.csproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.Utilities/HOK.RoomMeasure/HOK.RoomMeasure.csproj
+++ b/HOK.Utilities/HOK.RoomMeasure/HOK.RoomMeasure.csproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.Utilities/HOK.RoomUpdater/HOK.RoomUpdater.csproj
+++ b/HOK.Utilities/HOK.RoomUpdater/HOK.RoomUpdater.csproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.Utilities/HOK.ViewDepth/HOK.ViewDepth.csproj
+++ b/HOK.Utilities/HOK.ViewDepth/HOK.ViewDepth.csproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.Utilities/HOK.WorksetView/HOK.WorksetView.csproj
+++ b/HOK.Utilities/HOK.WorksetView/HOK.WorksetView.csproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.Utilities/HOK.XYZLocator/HOK.XYZLocator.csproj
+++ b/HOK.Utilities/HOK.XYZLocator/HOK.XYZLocator.csproj
@@ -19,7 +19,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/HOK.ViewAnalysis/HOK.ViewAnalysis/HOK.ViewAnalysis.csproj
+++ b/HOK.ViewAnalysis/HOK.ViewAnalysis/HOK.ViewAnalysis.csproj
@@ -18,7 +18,7 @@
     <Copyright>Copyright © HOK Group 2025</Copyright>
     <RepositoryUrl>https://github.com/HOKGroup/HOK-Revit-Addins</RepositoryUrl>
     <PackageProjectUrl>https://github.com/HOKGroup/HOK-Revit-Addins</PackageProjectUrl>
-    <Version>0.1.0.26</Version>
+    <Version>0.1.0.28</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HOK-Revit-Addins 2024.1.0.26
+# HOK-Revit-Addins 2025.1.0.28
 
 ### Code Signing
 

--- a/_build/build.yml
+++ b/_build/build.yml
@@ -78,8 +78,8 @@ jobs:
   - task: DotNetCoreCLI@2
     inputs:
       command: 'custom'
-      custom: 'nuget add source'
-      arguments: '--username dan.siroky --password $(DEVOPS_PAT) --store-password-in-clear-text --name HOK.Revit.Nuget  "https://pkgs.dev.azure.com/hok-appdev/HOK-Revit-Addins/_packaging/HOK.Revit.Nuget/nuget/v3/index.json"'
+      custom: 'nuget'
+      arguments: 'add source --username dan.siroky --password $(DEVOPS_PAT) --store-password-in-clear-text --name HOK.Revit.Nuget  "https://pkgs.dev.azure.com/hok-appdev/HOK-Revit-Addins/_packaging/HOK.Revit.Nuget/nuget/v3/index.json"'
 
   - task: DotNetCoreCLI@2
     inputs:

--- a/_build/build.yml
+++ b/_build/build.yml
@@ -13,6 +13,7 @@ jobs:
 
   variables:
   - group: code-signing
+  - group: artifacts-feed
   - name: solution
     value: '**/HOK.!(Core|MissionControl|Feedback|ParameterTools|FileOpeningMonitor|ModelReporting|SheetManager).sln'
   - name: coreSolution
@@ -59,16 +60,6 @@ jobs:
       Contents: '$(SettingsFileName)'
       TargetFolder: '$(Build.SourcesDirectory)/HOK.Core/HOK.Core/Resources'
 
-  - task: DownloadSecureFile@1
-    inputs:
-      secureFile: 'nuget.config'
-
-  - task: CopyFiles@2
-    inputs:
-      SourceFolder: '$(Agent.TempDirectory)'
-      Contents: 'nuget.config'
-      TargetFolder: '$(Build.SourcesDirectory)/HOK.MissonControl'
-
   - task: PowerShell@2
     inputs:
       targetType: 'inline'
@@ -83,6 +74,12 @@ jobs:
       SourceFolder: '$(Agent.TempDirectory)'
       Contents: 'CISign.pfx'
       TargetFolder: '$(Build.SourcesDirectory)/_cert'
+
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: 'custom'
+      custom: 'nuget add source'
+      arguments: '--username dan.siroky --password $(DEVOPS_PAT) --store-password-in-clear-text --name HOK.Revit.Nuget  "https://pkgs.dev.azure.com/hok-appdev/HOK-Revit-Addins/_packaging/HOK.Revit.Nuget/nuget/v3/index.json"'
 
   - task: DotNetCoreCLI@2
     inputs:

--- a/_build/build.yml
+++ b/_build/build.yml
@@ -59,6 +59,16 @@ jobs:
       Contents: '$(SettingsFileName)'
       TargetFolder: '$(Build.SourcesDirectory)/HOK.Core/HOK.Core/Resources'
 
+  - task: DownloadSecureFile@1
+    inputs:
+      secureFile: 'nuget.config'
+
+  - task: CopyFiles@2
+    inputs:
+      SourceFolder: '$(Agent.TempDirectory)'
+      Contents: 'nuget.config'
+      TargetFolder: '$(Build.SourcesDirectory)/HOK.MissonControl'
+
   - task: PowerShell@2
     inputs:
       targetType: 'inline'


### PR DESCRIPTION
## Description
Due to [DLL hell](https://en.wikipedia.org/wiki/DLL_hell), it seems that there were some conflicts between add-ins using RestSharp, causing errors + problems with deserialization. While there have been some improvements in Revit 2025 and beyond to incorporate dependency isolation (see this [useful video](https://www.youtube.com/watch?v=cpy4J_6-8WY)), until 2025 is the oldest version we support, we'll want to incorporate some way of isolating common dependencies-- in this case RestSharp. This PR incorporates the method outlined by Konrad [here](https://archi-lab.net/shining-some-light-at-the-dll-hell/).

Additionally, instead of relying on RestSharp to deserialize our data models, we're using the `HOK.Core.Json` class to do so.