### PR TITLE
0.1.0.28: Add Serialize method to HOK.Core and use it with HTTP requests

### DIFF
--- a/HOK.Core/HOK.Core/Utilities/Json.cs
+++ b/HOK.Core/HOK.Core/Utilities/Json.cs
@@ -23,6 +23,31 @@ namespace HOK.Core.Utilities
         /// 
         /// </summary>
         /// <typeparam name="T"></typeparam>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        public static string Serialize<T>(T data)
+        {
+            try
+            {
+                var options = new JsonSerializerOptions
+                {
+                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+                    UnmappedMemberHandling = JsonUnmappedMemberHandling.Skip,
+                };
+                options.Converters.Add(new JsonStringEnumConverter());
+                var jsonString = JsonSerializer.Serialize<T>(data, options);
+                return jsonString;
+            }
+            catch (Exception)
+            {
+                throw new Exception("Failed to serialize object into a valid json string");
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
         /// <param name="json"></param>
         /// <returns></returns>
         public static T Deserialize<T>(string json) where T : new()

--- a/HOK.MissionControl/HOK.MissionControl.Core/Utils/ServerUtilities.cs
+++ b/HOK.MissionControl/HOK.MissionControl.Core/Utils/ServerUtilities.cs
@@ -201,7 +201,8 @@ namespace HOK.MissionControl.Core.Utils
 
                 var request = new RestRequest(ApiVersion + "/" + route, Method.Put);
                 request.RequestFormat = DataFormat.Json;
-                request.AddJsonBody(body);
+                var jsonBody = Json.Serialize<T>(body);
+                request.AddBody(jsonBody, "application/json");
 
                 var response = client.Execute(request);
                 if (response.StatusCode != HttpStatusCode.Created)
@@ -233,7 +234,8 @@ namespace HOK.MissionControl.Core.Utils
 
             var request = new RestRequest(ApiVersion + "/" + route, Method.Post);
             request.RequestFormat = DataFormat.Json;
-            request.AddJsonBody(body);
+            var jsonBody = Json.Serialize(body);
+            request.AddBody(jsonBody, "application/json");
 
             var response = await client.ExecuteAsync(request);
             if (response.StatusCode != HttpStatusCode.Created)
@@ -272,7 +274,8 @@ namespace HOK.MissionControl.Core.Utils
 
                 var request = new RestRequest(ApiVersion + "/" + route, Method.Post);
                 request.RequestFormat = DataFormat.Json;
-                request.AddJsonBody(body);
+                var jsonBody = Json.Serialize(body);
+                request.AddBody(jsonBody, "application/json");
 
                 var response = client.Execute(request);
                 if (response.StatusCode != HttpStatusCode.Created)


### PR DESCRIPTION
## Description
After switching from Newtonsoft.Json to System.Text.Json, we encountered issues with fields returning `null` or being sent with null values. #232 resolved the latter, but the default settings for System.Text.Json mapped fields that didn't have values, whereas Newtonsoft did not. This caused some server errors on the Mission Control backend, but would be fixed by this PR. I have tested with 2 other users aside from myself.