### PR TITLE
Added code for adding all sheets to a print set on sync

### DIFF
--- a/HOK.Core/HOK.Core/BackgroundTasks/Rules.cs
+++ b/HOK.Core/HOK.Core/BackgroundTasks/Rules.cs
@@ -88,21 +88,12 @@ namespace HOK.Core.BackgroundTasks
                     ss => ss.Name == "_HOK Automated Print Set"
                 );
 
-            // Get all of the sheets in the document
-            List<ElementId> sheetsInDocIds = new FilteredElementCollector(doc)
+            List<ElementId> sheetsInModel = new FilteredElementCollector(doc)
                 .OfClass(typeof(ViewSheet))
                 .ToElements()
                 .Cast<ViewSheet>()
                 .Select(s => s.Id)
                 .ToList();
-
-            List<ElementId> sheetsInModel = new List<ElementId>();
-
-            foreach (ElementId viewId in sheetsInDocIds)
-            {
-                View view = (View)doc.GetElement(viewId);
-                sheetsInModel.Add(viewId);
-            }
 
             // Add the excluded sheets to the sheet set
             ViewSet newVSS = new ViewSet();

--- a/HOK.Core/HOK.Core/BackgroundTasks/Rules.cs
+++ b/HOK.Core/HOK.Core/BackgroundTasks/Rules.cs
@@ -10,7 +10,7 @@ using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.Architecture;
 using Autodesk.Revit.UI;
 
-namespace HOK.Core.IDCRevit
+namespace HOK.Core.BackgroundTasks
 {
     public static class Rules
     {

--- a/HOK.Core/HOK.Core/BackgroundTasks/Rules.cs
+++ b/HOK.Core/HOK.Core/BackgroundTasks/Rules.cs
@@ -15,12 +15,15 @@ namespace HOK.Core.BackgroundTasks
 {
     public static class Rules
     {
+        const string HOK_PRINT_SET_PARAM_NAME = "Add ALL Sheets to HOK Print Set";
+        const string HOK_PRINT_SET_NAME = "_HOK Automated Print Set";
+
         public static void AddAllSheetsToPrintSet(Document doc)
         {
-            // First ensure that the "Add ALL Sheets to HOK Print Set" parameter exists and is enabled
+            // First ensure that the HOK_PRINT_SET_PARAM_NAME parameter exists and is enabled
             var hokPrintSetParamId = GlobalParametersManager.FindByName(
                 doc,
-                "Add ALL Sheets to HOK Print Set"
+                HOK_PRINT_SET_PARAM_NAME
             );
 
             // If parameter is not found, create it
@@ -33,7 +36,7 @@ namespace HOK.Core.BackgroundTasks
                     {
                         GlobalParameter hokPrintSetParam = GlobalParameter.Create(
                             doc,
-                            "Add ALL Sheets to HOK Print Set",
+                            HOK_PRINT_SET_PARAM_NAME,
 #if REVIT2022_OR_GREATER
                             SpecTypeId.Boolean.YesNo
 #else
@@ -48,7 +51,7 @@ namespace HOK.Core.BackgroundTasks
                         tr.Start();
                         GlobalParameter hokPrintSetParam = GlobalParameter.Create(
                             doc,
-                            "Add ALL Sheets to HOK Print Set",
+                            HOK_PRINT_SET_PARAM_NAME,
 #if REVIT2022_OR_GREATER
                             SpecTypeId.Boolean.YesNo
 #else
@@ -63,7 +66,7 @@ namespace HOK.Core.BackgroundTasks
             }
             hokPrintSetParamId = GlobalParametersManager.FindByName(
                 doc,
-                "Add ALL Sheets to HOK Print Set"
+                HOK_PRINT_SET_PARAM_NAME
             );
             try
             {
@@ -94,9 +97,9 @@ namespace HOK.Core.BackgroundTasks
                 .OfClass(typeof(ViewSheetSet))
                 .Cast<ViewSheetSet>();
 
-            if (hokSheetSet.Select(ss => ss.Name).Contains("_HOK Automated Print Set"))
+            if (hokSheetSet.Select(ss => ss.Name).Contains(HOK_PRINT_SET_NAME))
                 existingVSS.CurrentViewSheetSet = hokSheetSet.First(
-                    ss => ss.Name == "_HOK Automated Print Set"
+                    ss => ss.Name == HOK_PRINT_SET_NAME
                 );
 
             List<ElementId> sheetsInModel = new FilteredElementCollector(doc)
@@ -123,7 +126,7 @@ namespace HOK.Core.BackgroundTasks
                     if (
                         hokSheetSet != null
                         && ((ViewSheetSet)existingVSS.CurrentViewSheetSet).Name
-                            == "_HOK Automated Print Set"
+                            == HOK_PRINT_SET_NAME
                     )
                     {
                         try
@@ -139,7 +142,7 @@ namespace HOK.Core.BackgroundTasks
                     else
                     {
                         existingVSS.CurrentViewSheetSet.Views = newVSS;
-                        existingVSS.SaveAs("_HOK Automated Print Set");
+                        existingVSS.SaveAs(HOK_PRINT_SET_NAME);
                     }
                 }
                 else
@@ -148,7 +151,7 @@ namespace HOK.Core.BackgroundTasks
                     if (
                         hokSheetSet != null
                         && ((ViewSheetSet)existingVSS.CurrentViewSheetSet).Name
-                            == "_HOK Automated Print Set"
+                            == HOK_PRINT_SET_NAME
                     )
                     {
                         try
@@ -161,7 +164,7 @@ namespace HOK.Core.BackgroundTasks
                     else
                     {
                         existingVSS.CurrentViewSheetSet.Views = newVSS;
-                        existingVSS.SaveAs("_HOK Automated Print Set");
+                        existingVSS.SaveAs(HOK_PRINT_SET_NAME);
                     }
                     tr.Commit();
                 }

--- a/HOK.Core/HOK.Core/BackgroundTasks/Rules.cs
+++ b/HOK.Core/HOK.Core/BackgroundTasks/Rules.cs
@@ -33,7 +33,11 @@ namespace HOK.Core.BackgroundTasks
                         GlobalParameter hokPrintSetParam = GlobalParameter.Create(
                             doc,
                             "Add ALL Sheets to HOK Print Set",
+#if REVIT2022_OR_GREATER
                             SpecTypeId.Boolean.YesNo
+#else
+                            ParameterType.YesNo
+#endif
                         );
                         // Set the default value to off/false
                         hokPrintSetParam.SetValue(new IntegerParameterValue(1));
@@ -44,7 +48,11 @@ namespace HOK.Core.BackgroundTasks
                         GlobalParameter hokPrintSetParam = GlobalParameter.Create(
                             doc,
                             "Add ALL Sheets to HOK Print Set",
+#if REVIT2022_OR_GREATER
                             SpecTypeId.Boolean.YesNo
+#else
+                            ParameterType.YesNo
+#endif
                         );
                         // Set the default value to off/false
                         hokPrintSetParam.SetValue(new IntegerParameterValue(1));
@@ -66,7 +74,7 @@ namespace HOK.Core.BackgroundTasks
                 return;
             }
 
-        AddAllSheets:
+            AddAllSheets:
             PrintManager pm = doc.PrintManager;
 
             // Ensure that the print manager setting is set to selected views

--- a/HOK.Core/HOK.Core/IDCRevit/Rules.cs
+++ b/HOK.Core/HOK.Core/IDCRevit/Rules.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Net;
+using System.Runtime.ExceptionServices;
+using System.Text;
+using System.Threading.Tasks;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Architecture;
+using Autodesk.Revit.UI;
+
+namespace HOK.Core.IDCRevit
+{
+    public static class Rules
+    {
+        public static void AddAllSheetsToPrintSet(Document doc)
+        {
+            // First ensure that the "Add ALL Sheets to HOK Print Set" parameter exists and is enabled
+            var hokPrintSetParamId = GlobalParametersManager.FindByName(
+                doc,
+                "Add ALL Sheets to HOK Print Set"
+            );
+
+            // If parameter is not found, create it
+            if (hokPrintSetParamId == ElementId.InvalidElementId)
+            {
+                // Creating the parameter
+                using (Transaction tr = new Transaction(doc, "Create HOK Print Set Parameter"))
+                {
+                    if (doc.IsModifiable)
+                    {
+                        GlobalParameter hokPrintSetParam = GlobalParameter.Create(
+                            doc,
+                            "Add ALL Sheets to HOK Print Set",
+                            SpecTypeId.Boolean.YesNo
+                        );
+                        // Set the default value to off/false
+                        hokPrintSetParam.SetValue(new IntegerParameterValue(1));
+                    }
+                    else
+                    {
+                        tr.Start();
+                        GlobalParameter hokPrintSetParam = GlobalParameter.Create(
+                            doc,
+                            "Add ALL Sheets to HOK Print Set",
+                            SpecTypeId.Boolean.YesNo
+                        );
+                        // Set the default value to off/false
+                        hokPrintSetParam.SetValue(new IntegerParameterValue(1));
+                        tr.Commit();
+                    }
+                }
+            }
+            hokPrintSetParamId = GlobalParametersManager.FindByName(
+                doc,
+                "Add ALL Sheets to HOK Print Set"
+            );
+            var hokPrintSetParameter = doc.GetElement(hokPrintSetParamId) as GlobalParameter;
+            if ((hokPrintSetParameter.GetValue() as IntegerParameterValue).Value == 1)
+            {
+                goto AddAllSheets;
+            }
+            else
+            {
+                return;
+            }
+
+        AddAllSheets:
+            PrintManager pm = doc.PrintManager;
+
+            // Ensure that the print manager setting is set to selected views
+            if (pm.PrintRange != PrintRange.Select)
+            {
+                pm.PrintRange = PrintRange.Select;
+            }
+
+            ViewSheetSetting existingVSS = pm.ViewSheetSetting;
+            // Save the previously selected viewsheet set so we can set it back to the original at the end
+            var existingViewSheetSet = existingVSS.CurrentViewSheetSet;
+
+            var hokSheetSet = new FilteredElementCollector(doc)
+                .OfClass(typeof(ViewSheetSet))
+                .Cast<ViewSheetSet>();
+
+            if (hokSheetSet.Select(ss => ss.Name).Contains("_HOK Automated Print Set"))
+                existingVSS.CurrentViewSheetSet = hokSheetSet.First(
+                    ss => ss.Name == "_HOK Automated Print Set"
+                );
+
+            // Get all of the sheets in the document
+            List<ElementId> sheetsInDocIds = new FilteredElementCollector(doc)
+                .OfClass(typeof(ViewSheet))
+                .ToElements()
+                .Cast<ViewSheet>()
+                .Select(s => s.Id)
+                .ToList();
+
+            List<ElementId> sheetsInModel = new List<ElementId>();
+
+            foreach (ElementId viewId in sheetsInDocIds)
+            {
+                View view = (View)doc.GetElement(viewId);
+                sheetsInModel.Add(viewId);
+            }
+
+            // Add the excluded sheets to the sheet set
+            ViewSet newVSS = new ViewSet();
+            foreach (var viewId in sheetsInModel)
+            {
+                View currView = (View)doc.GetElement(viewId);
+                if (!newVSS.Contains(currView))
+                {
+                    newVSS.Insert(currView);
+                }
+                else
+                {
+                    continue;
+                }
+            }
+            using (Transaction tr = new Transaction(doc, "Add Sheets to View Sheet Set"))
+            {
+                if (doc.IsModifiable)
+                {
+                    if (
+                        hokSheetSet != null
+                        && ((ViewSheetSet)existingVSS.CurrentViewSheetSet).Name
+                            == "_HOK Automated Print Set"
+                    )
+                    {
+                        try
+                        {
+                            existingVSS.CurrentViewSheetSet.Views = newVSS;
+                            existingVSS.Save();
+                        }
+                        catch { }
+                    }
+                    else
+                    {
+                        existingVSS.CurrentViewSheetSet.Views = newVSS;
+                        existingVSS.SaveAs("_HOK Automated Print Set");
+                    }
+                }
+                else
+                {
+                    tr.Start();
+                    if (
+                        hokSheetSet != null
+                        && ((ViewSheetSet)existingVSS.CurrentViewSheetSet).Name
+                            == "_HOK Automated Print Set"
+                    )
+                    {
+                        try
+                        {
+                            existingVSS.CurrentViewSheetSet.Views = newVSS;
+                            existingVSS.Save();
+                        }
+                        catch { }
+                    }
+                    else
+                    {
+                        existingVSS.CurrentViewSheetSet.Views = newVSS;
+                        existingVSS.SaveAs("_HOK Automated Print Set");
+                    }
+                    tr.Commit();
+                }
+            }
+        }
+    }
+}

--- a/HOK.RibbonTab/HOK.RibbonTab/AppCommand.cs
+++ b/HOK.RibbonTab/HOK.RibbonTab/AppCommand.cs
@@ -27,9 +27,7 @@ namespace HOK.RibbonTab
         {
             Application.ControlledApplication.DocumentOpening += OnDocumentOpening;
             Application.ControlledApplication.DocumentCreating += OnDocumentCreating;
-#if REVIT2022_OR_GREATER
             Application.ControlledApplication.DocumentSynchronizingWithCentral += OnDocumentSynchronizing;
-#endif
             m_app = Application;
             tabName = "   HOK   ";
             
@@ -56,12 +54,10 @@ namespace HOK.RibbonTab
             //CreateMissionControlPushButtons();
         }
 
-#if REVIT2022_OR_GREATER
         private void OnDocumentSynchronizing(object sender, DocumentSynchronizingWithCentralEventArgs e)
         {
             HOK.Core.BackgroundTasks.Rules.AddAllSheetsToPrintSet(e.Document);
         }
-#endif
 
         private static void OnDocumentCreating(object sender, DocumentCreatingEventArgs args)
         {

--- a/HOK.RibbonTab/HOK.RibbonTab/AppCommand.cs
+++ b/HOK.RibbonTab/HOK.RibbonTab/AppCommand.cs
@@ -56,7 +56,14 @@ namespace HOK.RibbonTab
 
         private void OnDocumentSynchronizing(object sender, DocumentSynchronizingWithCentralEventArgs e)
         {
-            HOK.Core.BackgroundTasks.Rules.AddAllSheetsToPrintSet(e.Document);
+            try
+            {
+                HOK.Core.BackgroundTasks.Rules.AddAllSheetsToPrintSet(e.Document);
+            }
+            catch (Exception ex)
+            {
+                Log.AppendLog(LogMessageType.EXCEPTION, "Failed to execute method in OnDocumentSynchronizing." + ex.Message);
+            }
         }
 
         private static void OnDocumentCreating(object sender, DocumentCreatingEventArgs args)

--- a/HOK.RibbonTab/HOK.RibbonTab/AppCommand.cs
+++ b/HOK.RibbonTab/HOK.RibbonTab/AppCommand.cs
@@ -27,6 +27,7 @@ namespace HOK.RibbonTab
         {
             Application.ControlledApplication.DocumentOpening += OnDocumentOpening;
             Application.ControlledApplication.DocumentCreating += OnDocumentCreating;
+            Application.ControlledApplication.DocumentSynchronizingWithCentral += OnDocumentSynchronizing;
             m_app = Application;
             tabName = "   HOK   ";
             
@@ -51,6 +52,11 @@ namespace HOK.RibbonTab
             //CreateDataPushButtons();
             CreateAvfPushButtons();
             //CreateMissionControlPushButtons();
+        }
+
+        private void OnDocumentSynchronizing(object sender, DocumentSynchronizingWithCentralEventArgs e)
+        {
+            HOK.Core.BackgroundTasks.Rules.AddAllSheetsToPrintSet(e.Document);
         }
 
         private static void OnDocumentCreating(object sender, DocumentCreatingEventArgs args)

--- a/HOK.RibbonTab/HOK.RibbonTab/AppCommand.cs
+++ b/HOK.RibbonTab/HOK.RibbonTab/AppCommand.cs
@@ -27,7 +27,9 @@ namespace HOK.RibbonTab
         {
             Application.ControlledApplication.DocumentOpening += OnDocumentOpening;
             Application.ControlledApplication.DocumentCreating += OnDocumentCreating;
+#if REVIT2022_OR_GREATER
             Application.ControlledApplication.DocumentSynchronizingWithCentral += OnDocumentSynchronizing;
+#endif
             m_app = Application;
             tabName = "   HOK   ";
             
@@ -54,10 +56,12 @@ namespace HOK.RibbonTab
             //CreateMissionControlPushButtons();
         }
 
+#if REVIT2022_OR_GREATER
         private void OnDocumentSynchronizing(object sender, DocumentSynchronizingWithCentralEventArgs e)
         {
             HOK.Core.BackgroundTasks.Rules.AddAllSheetsToPrintSet(e.Document);
         }
+#endif
 
         private static void OnDocumentCreating(object sender, DocumentCreatingEventArgs args)
         {

--- a/HOK.RibbonTab/HOK.RibbonTab/HOK.RibbonTab.addin
+++ b/HOK.RibbonTab/HOK.RibbonTab/HOK.RibbonTab.addin
@@ -5,7 +5,7 @@
     <Assembly>HOK-Addin.bundle\Contents\HOK.RibbonTab.dll</Assembly>
     <AddInId>3A05AE7E-6097-4138-A466-703AB614020F</AddInId>
     <FullClassName>HOK.RibbonTab.AppCommand</FullClassName>
-    <VendorId>BuildingSMART</VendorId>
-    <VendorDescription>Konrad K Sobon</VendorDescription>
+    <VendorId>ADSK</VendorId>
+    <VendorDescription>ADSK</VendorDescription>
   </AddIn>
 </RevitAddIns>


### PR DESCRIPTION
## Description

The code in this pull request creates a new global parameter (if it doesn't exist already) in a Revit project called "Add ALL Sheets to HOK Print Set" that has a boolean value and is by default turned on. (This can be discussed on whether this should be turned on or off by default.) If this global parameter is turned on, then every time a user syncs their project with the central model, the new code will add all sheets that exist in the Revit project into a new print set called "_HOK Automated Print Set".

## Tasks
- [x] Submitted PR
- [ ] Published to BIM Staging
- [ ] Tested by David
- [ ] Published to BIM Master
