### PR TITLE
Hotfix for issue from Greg

### DIFF
--- a/HOK.Core/HOK.Core/BackgroundTasks/Rules.cs
+++ b/HOK.Core/HOK.Core/BackgroundTasks/Rules.cs
@@ -115,23 +115,28 @@ namespace HOK.Core.BackgroundTasks
             {
                 if (doc.IsModifiable)
                 {
-                    if (
-                        hokSheetSet != null
-                        && ((ViewSheetSet)existingVSS.CurrentViewSheetSet).Name
-                            == HOK_PRINT_SET_NAME
-                    )
+                    try
                     {
-                        try
+                        if (
+                            hokSheetSet != null
+                            && ((ViewSheetSet)existingVSS.CurrentViewSheetSet).Name
+                                == HOK_PRINT_SET_NAME
+                        )
+                        {
+                            try
+                            {
+                                existingVSS.CurrentViewSheetSet.Views = newVSS;
+                                existingVSS.Save();
+                            }
+                            catch (Exception ex) { }
+                        }
+                        else
                         {
                             existingVSS.CurrentViewSheetSet.Views = newVSS;
-                            existingVSS.Save();
-                        }
-                        catch (Exception ex)
-                        {
-                            Log.AppendLog(LogMessageType.EXCEPTION, "Failed to set sheets to print set \"_HOK Automated Print Set\". Exception message: " + ex.Message);
+                            existingVSS.SaveAs(HOK_PRINT_SET_NAME);
                         }
                     }
-                    else
+                    catch (Exception ex)
                     {
                         existingVSS.CurrentViewSheetSet.Views = newVSS;
                         existingVSS.SaveAs(HOK_PRINT_SET_NAME);
@@ -140,25 +145,35 @@ namespace HOK.Core.BackgroundTasks
                 else
                 {
                     tr.Start();
-                    if (
-                        hokSheetSet != null
-                        && ((ViewSheetSet)existingVSS.CurrentViewSheetSet).Name
-                            == HOK_PRINT_SET_NAME
-                    )
+                    try
                     {
-                        try
+                        if (
+                            hokSheetSet != null
+                            && ((ViewSheetSet)existingVSS.CurrentViewSheetSet).Name
+                                == HOK_PRINT_SET_NAME
+                        )
+                        {
+                            try
+                            {
+                                existingVSS.CurrentViewSheetSet.Views = newVSS;
+                                existingVSS.Save();
+                            }
+                            catch { }
+                        }
+                        else
                         {
                             existingVSS.CurrentViewSheetSet.Views = newVSS;
-                            existingVSS.Save();
+                            existingVSS.SaveAs(HOK_PRINT_SET_NAME);
                         }
-                        catch { }
                     }
-                    else
+                    catch (Exception ex)
                     {
                         existingVSS.CurrentViewSheetSet.Views = newVSS;
                         existingVSS.SaveAs(HOK_PRINT_SET_NAME);
+                        tr.Commit();
                     }
-                    tr.Commit();
+                    if(tr.GetStatus() != TransactionStatus.Committed)
+                        tr.Commit();
                 }
             }
 


### PR DESCRIPTION
- In a new project without any print sets, this whole function will not work.
- In a project without any print sets, on line 122 or 152, the cast will fail because the CurrentViewSheetSet is of type InSessionViewSheetSet, which can not be cast to ViewSheetSet
- Function works as a macro, was difficult to verify that it works as an add-in. Needs testing from others.

## Description

## Tasks
- [x] Submitted PR
- [ ] Published to BIM Staging
- [ ] Tested by David
- [ ] Published to BIM Master
